### PR TITLE
Do not depend on ZODB3 but only on the BTrees package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changes
 - Drop support for Python 2.7, 3.5, 3.6.
   [ale-rt]
 
+- Fix the dependency on the ZODB, we just need to depend on the BTrees package.
+  Refs. #11.
+  [ale-rt]
+
 
 1.2 (2023-03-28)
 ================

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     keywords="zope zope3 relation",
     python_requires='>=3.7',
     install_requires=[
-        'ZODB3 >= 3.8dev',
+        'BTrees',
         'zope.interface',
         'setuptools',
         'six',

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,8 @@ setup(
         'six',
         'zope.testing',
     ],
-    extras_require={'test': 'zc.relationship >= 2'},
+    extras_require={'test': [
+        'zc.relationship >= 2',
+        'ZODB'
+    ]},
 )


### PR DESCRIPTION
It seems to me the package can just depend on the BTrees package.

The only import on the ZODB happen in the doctests:
```
ale@avo:~/Code/plone/packages/zc.relation$ rg ZODB|rg import
src/zc/relation/README.rst:    >>> from ZODB.tests.util import DB
src/zc/relation/tokens.rst:    >>> from ZODB.tests.util import DB
```

Theoretically we could add the test dependency in the `extras_require` which now pulls in only `zc.relationship`:
```
    extras_require={'test': 'zc.relationship >= 2'},
```
Otherwise I will just do another PR that changes `ZODB3` to `ZODB`.