### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changes
 3.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes
 =======
 
 
-2.2 (unreleased)
+3.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -27,10 +26,7 @@ def read(path):
 setup(
     name="zc.relation",
     version='3.0.dev0',
-    packages=find_packages('src'),
     include_package_data=True,
-    package_dir={'': 'src'},
-    namespace_packages=['zc'],
     zip_safe=False,
     author='Gary Poster',
     author_email='zope-dev@zope.dev',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read(path):
 
 setup(
     name="zc.relation",
-    version='2.2.dev0',
+    version='3.0.dev0',
     packages=find_packages('src'),
     include_package_data=True,
     package_dir={'': 'src'},

--- a/src/zc/__init__.py
+++ b/src/zc/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
